### PR TITLE
Improve loading of playlist logic

### DIFF
--- a/src/main/java/me/afarrukh/hashbot/commands/audiotracks/playlist/LoadListCommand.java
+++ b/src/main/java/me/afarrukh/hashbot/commands/audiotracks/playlist/LoadListCommand.java
@@ -61,6 +61,7 @@ public class LoadListCommand extends Command implements AudioTrackCommand {
                     GuildAudioTrackManager guildAudioPlayer = Bot.trackManager.getGuildAudioPlayer(evt.getGuild());
                     var iterator = playlist.getItems().iterator();
                     var firstItem = iterator.next();
+                    // TODO change this logic here to speed up loading
                     playerManager.loadItemOrdered(
                             guildAudioPlayer, firstItem.uri(), new YTFirstLatentTrackHandler(member, memberId));
                     int idx = 0;

--- a/src/main/java/me/afarrukh/hashbot/commands/management/guild/SetPinThresholdCommand.java
+++ b/src/main/java/me/afarrukh/hashbot/commands/management/guild/SetPinThresholdCommand.java
@@ -5,9 +5,6 @@ import me.afarrukh.hashbot.commands.tagging.AdminCommand;
 import me.afarrukh.hashbot.data.Database;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
-/**
- * Created by Abdullah on 10/04/2019 16:10
- */
 public class SetPinThresholdCommand extends Command implements AdminCommand {
 
     public SetPinThresholdCommand() {

--- a/src/main/java/me/afarrukh/hashbot/commands/management/user/ClearCommand.java
+++ b/src/main/java/me/afarrukh/hashbot/commands/management/user/ClearCommand.java
@@ -17,9 +17,6 @@ import java.util.concurrent.TimeUnit;
 
 import static me.afarrukh.hashbot.utils.MessageUtils.deleteAllMessagesFromBin;
 
-/**
- * Created by Abdullah on 08/04/2019 20:22
- */
 public class ClearCommand extends Command implements AdminCommand {
     private static final Logger LOG = LoggerFactory.getLogger(ClearCommand.class);
 

--- a/src/main/java/me/afarrukh/hashbot/config/Constants.java
+++ b/src/main/java/me/afarrukh/hashbot/config/Constants.java
@@ -4,42 +4,25 @@ import java.awt.*;
 
 public class Constants {
     public static final int MAX_PLAYLIST_SIZE = 400;
-
-    // The amount of seconds to wait before disconnecting after a user leaves
     public static final int DISCONNECT_DELAY = 60 * 10;
     public static final int AudioTrackBAR_SCALE = 35;
 
-    // The maximum volume the bot can play at.
     public static final int MAX_VOL = 100;
     public static final String SELECTEDPOS = "full_moon";
     public static final String UNSELECTEDPOS = "=";
 
-    // The default color for embeds
     public static final Color EMB_COL = new Color(100, 243, 213);
     public static final int PIN_THRESHOLD = 1;
     public static long timeStarted = 0;
     public static final Long INITIAL_MEMORY =
             Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
-    // The limit of a playlist that can be created within the bot
     public static final int CUSTOM_PLAYLIST_SIZE_LIMIT = 100;
 
     // How often to update the message when loading or creating a new playlist through the bot
     public static final int PLAYLIST_UPDATE_INTERVAL = 10;
 
-    private static Constants instance;
-
-    private Constants() {}
-
-    public static Constants getInstance() {
-        if (instance == null) {
-            instance = new Constants();
-        }
-        return instance;
-    }
-
     public static void init() {
         timeStarted = System.currentTimeMillis();
-        getInstance();
     }
 }

--- a/src/main/java/me/afarrukh/hashbot/track/AudioPlayerSendHandler.java
+++ b/src/main/java/me/afarrukh/hashbot/track/AudioPlayerSendHandler.java
@@ -6,18 +6,13 @@ import net.dv8tion.jda.api.audio.AudioSendHandler;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
-/**
- * Required to function with JDA and provide correct compatibility
- */
+import static java.util.Objects.requireNonNull;
+
 public class AudioPlayerSendHandler implements AudioSendHandler {
     private final AudioPlayer audioPlayer;
     private AudioFrame lastFrame;
 
-    /**
-     * @param audioPlayer Audio player to wrap.
-     */
     public AudioPlayerSendHandler(AudioPlayer audioPlayer) {
         this.audioPlayer = audioPlayer;
     }
@@ -41,7 +36,7 @@ public class AudioPlayerSendHandler implements AudioSendHandler {
         byte[] data = lastFrame != null ? lastFrame.getData() : null;
         lastFrame = null;
 
-        return ByteBuffer.wrap(Objects.requireNonNull(data));
+        return ByteBuffer.wrap(requireNonNull(data));
     }
 
     @Override

--- a/src/main/java/me/afarrukh/hashbot/track/GuildAudioTrackManager.java
+++ b/src/main/java/me/afarrukh/hashbot/track/GuildAudioTrackManager.java
@@ -6,9 +6,6 @@ import net.dv8tion.jda.api.entities.Guild;
 
 import java.util.Timer;
 
-/**
- * Object that binds a guild to a player and track scheduler
- */
 public class GuildAudioTrackManager {
     private final AudioPlayer player;
     private final TrackScheduler scheduler;

--- a/src/main/java/me/afarrukh/hashbot/track/LatentTrack.java
+++ b/src/main/java/me/afarrukh/hashbot/track/LatentTrack.java
@@ -4,54 +4,26 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 
 public class LatentTrack implements Runnable {
 
-    /**
-     * The associated audio track with this object
-     */
     private final AudioTrack track;
 
-    /**
-     * The position of this audio track in the loader
-     */
     private final int pos;
 
-    /**
-     * The playlist loader that serves as the "barrier" for this track, and tracks
-     * that are part of the same playlist
-     */
     private final PlaylistLoader loader;
 
-    /**
-     * Instantiates this object
-     *
-     * @param track  The track to be wrapped
-     * @param pos    The position of this track
-     * @param loader The associated <code>PlaylistLoader</code>
-     */
     public LatentTrack(AudioTrack track, int pos, PlaylistLoader loader) {
         this.track = track;
         this.pos = pos;
         this.loader = loader;
     }
 
-    /**
-     * Return the wrapped track
-     *
-     * @return The internal AudioTrack object
-     */
     public AudioTrack getTrack() {
         return track;
     }
 
-    /**
-     * @return The position of this track in the <code>PlaylistLoader</code>
-     */
     public int getPos() {
         return pos;
     }
 
-    /**
-     * Add the track to the playlist loader
-     */
     @Override
     public void run() {
         try {

--- a/src/main/java/me/afarrukh/hashbot/track/PlaylistLoader.java
+++ b/src/main/java/me/afarrukh/hashbot/track/PlaylistLoader.java
@@ -11,46 +11,20 @@ import java.util.List;
 
 public class PlaylistLoader {
 
-    /**
-     * The list of <code>AudioTrack</code> objects to be queued.
-     */
     private final List<LatentTrack> tracks;
-    /**
-     * The associated member object, for use in deciding which guild to send messages to,
-     * and which member to join
-     */
+
     private final Member member;
-    /**
-     * The message object to update once the playlist has completed loading
-     */
+
     private final Message message;
-    /**
-     * The name of the playlist. For use in printing the final message to be sent to the user once the playlist
-     * has finished loading
-     */
+
     private final String listName;
-    /**
-     * The original size of the playlist
-     */
+
     private final int originalSize;
-    /**
-     * The original size of the playlist
-     * We aim to count upwards towards this as we add tracks to this "barrier"
-     */
+
     private int maxSize;
-    /**
-     * The current index of the playlist, as mentioned, this is counting up towards maxSize (well technically maxSize-1)
-     */
+
     private int currentIndex;
 
-    /**
-     * Create a new playlist loader object
-     *
-     * @param member   The associated member object with this loader
-     * @param maxSize  The maximum size of the playlist
-     * @param message  The associated message object to be updated once the playlist has been loaded
-     * @param listName The name of the playlist
-     */
     public PlaylistLoader(Member member, int maxSize, Message message, String listName) {
         this.maxSize = maxSize;
         this.member = member;
@@ -61,15 +35,6 @@ public class PlaylistLoader {
         originalSize = maxSize;
     }
 
-    /**
-     * This deals with adding tracks to the track list. This keeps track of all the tracks that have been added
-     * to the track list. Once the size of the track list matches the maximum intended size of the playlist,
-     * the tracks are let out of the "barrier", into the live track queue on the bot
-     *
-     * @param track The track to be added to the queue. Note that this is not an AudioTrack, and is actually a
-     *              <code>LatentTrack object</code>
-     * @throws InterruptedException This is thrown naturally by the wait() function call. We don't handle it here
-     */
     public synchronized void addTrack(LatentTrack track) throws InterruptedException {
 
         // We want to add the first track, so in case there are no tracks in the queue, the user can listen to the first

--- a/src/main/java/me/afarrukh/hashbot/track/TrackScheduler.java
+++ b/src/main/java/me/afarrukh/hashbot/track/TrackScheduler.java
@@ -54,20 +54,11 @@ public class TrackScheduler extends AudioEventAdapter {
         player.startTrack(queue.poll(), false);
     }
 
-    /**
-     * Decides what happens when the track ends
-     *
-     * @param player The AudioPlayer associated with this trackscheduler
-     * @param track  The track that has been started
-     */
     @Override
     public void onTrackStart(AudioPlayer player, AudioTrack track) {
         Bot.trackManager.getGuildAudioPlayer(guild).resetDisconnectTimer();
     }
 
-    /**
-     * Decides what happens when a track ends
-     */
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         // Only start the next track if the current one is finished
@@ -93,30 +84,15 @@ public class TrackScheduler extends AudioEventAdapter {
         }
     }
 
-    /**
-     * Replaces the current queue with a new one
-     *
-     * @param collection The collection to replace the current queue with
-     */
     public void replaceQueue(Collection<AudioTrack> collection) {
         queue = new LinkedBlockingQueue<>(collection);
     }
 
-    /**
-     * Converts a BlockingQueue<> into an Arraylist<>
-     *
-     * @return The current track list in an arraylist format
-     */
     public List<AudioTrack> getAsArrayList() {
         // Convert the queue into an arraylist
         return new ArrayList<>(this.queue);
     }
 
-    /**
-     * Gets the duration of the queue's AudioTracks and the remaining time of the current track
-     *
-     * @return Returns a string in format h:m:s of the total queue time
-     */
     public String getTotalQueueTime() {
         long count = 0;
 
@@ -132,11 +108,6 @@ public class TrackScheduler extends AudioEventAdapter {
                 TimeUnit.MILLISECONDS.toSeconds(count) % TimeUnit.MINUTES.toSeconds(1));
     }
 
-    /**
-     * Skips to desired index
-     *
-     * @param index The index to skip to in the queue
-     */
     public void skip(int index) {
         for (int i = 0; i < index - 1; i++) {
             queue.poll();
@@ -157,12 +128,6 @@ public class TrackScheduler extends AudioEventAdapter {
         }
     }
 
-    /**
-     * Gets the index of a given track (starts at 1 for user purposes)
-     *
-     * @param targetTrack The AudioTrack for which the index is to be found
-     * @return The index of the provided track
-     */
     public int getTrackIndex(AudioTrack targetTrack) {
         int count = 1;
         for (AudioTrack track : queue) {
@@ -174,12 +139,6 @@ public class TrackScheduler extends AudioEventAdapter {
         return count;
     }
 
-    /**
-     * Moves a track from one index to another
-     *
-     * @param originalPosition The track's current index
-     * @param newPosition      The desired index
-     */
     public void move(int originalPosition, int newPosition) {
         List<AudioTrack> trackList = getAsArrayList();
         try {
@@ -202,12 +161,6 @@ public class TrackScheduler extends AudioEventAdapter {
         }
     }
 
-    /**
-     * Gets the total time until an audio track that has been added to the end of the queue
-     *
-     * @param track The audio track for which the time is to be calculated
-     * @return Returns a string in HHMMSS format corresponding to how long until the track is playing
-     */
     public String getTotalTimeTil(AudioTrack track) {
         int trackBeforeTargetIndex = getTrackIndex(track) - 1;
         long totalTime = 0;
@@ -221,9 +174,6 @@ public class TrackScheduler extends AudioEventAdapter {
         return CmdUtils.longToHHMMSS(totalTime);
     }
 
-    /**
-     * Shuffles the queue
-     */
     public void shuffleAndReplace() {
         // Convert the queue to arraylist
         List<AudioTrack> trackList = getAsArrayList();
@@ -310,20 +260,10 @@ public class TrackScheduler extends AudioEventAdapter {
         return queue;
     }
 
-    /**
-     * Returns the looping status of the track scheduler
-     *
-     * @return a boolean corresponding as to whether or not the track is looping
-     */
     public boolean isLooping() {
         return looping;
     }
 
-    /**
-     * Changes the looping status of the track scheduler
-     *
-     * @param loop The boolean status to which the looping is set to
-     */
     public void setLooping(boolean loop) {
         looping = loop;
     }
@@ -336,9 +276,6 @@ public class TrackScheduler extends AudioEventAdapter {
         this.loopingQueue = loopingQueue;
     }
 
-    /**
-     * @return The guild associated with this track scheduler
-     */
     public Guild getGuild() {
         return this.guild;
     }

--- a/src/main/java/me/afarrukh/hashbot/utils/AudioTrackUtils.java
+++ b/src/main/java/me/afarrukh/hashbot/utils/AudioTrackUtils.java
@@ -15,12 +15,6 @@ import java.util.concurrent.BlockingQueue;
 
 public class AudioTrackUtils {
 
-    /**
-     * @param evt          The message event used to retrieve data such as the channel the message is being sent to
-     * @param trackManager The track manager to be queried
-     * @param track        The track being queued
-     * @param playTop      Whether or not the track is to be queued to the top of the list
-     */
     public static void play(
             MessageReceivedEvent evt, GuildAudioTrackManager trackManager, AudioTrack track, boolean playTop) {
 
@@ -67,12 +61,6 @@ public class AudioTrackUtils {
         gm.getPlayer().destroy();
     }
 
-    /**
-     * Returns the duration of a playlist
-     *
-     * @param pl The playlist to be queried
-     * @return A string with the duration of the playlist in HHMMSS format
-     */
     public static String getPlaylistDuration(AudioPlaylist pl) {
         long duration = 0;
         for (AudioTrack t : pl.getTracks()) {
@@ -82,10 +70,6 @@ public class AudioTrackUtils {
         return CmdUtils.longToHHMMSS(duration);
     }
 
-    /**
-     * @param evt The event associated with the call
-     * @return True or false depending on whether track commands can be called
-     */
     public static boolean canInteract(MessageReceivedEvent evt) {
         if (evt.getGuild()
                                 .getMemberById(Bot.botUser().getSelfUser().getId())
@@ -103,12 +87,6 @@ public class AudioTrackUtils {
                 .equals(evt.getMember().getVoiceState().getChannel());
     }
 
-    /**
-     * Gets the URL for the thumbnail for the provided track
-     *
-     * @param at The audio track for which the thumbnail URl is to be found
-     * @return A string with the URL to the given audio track
-     */
     public static String getThumbnailURL(AudioTrack at) {
         String vidURL = at.getInfo().uri;
         int idx = vidURL.indexOf("?v=");
@@ -116,10 +94,6 @@ public class AudioTrackUtils {
         return "https://img.youtube.com/vi/" + imgURL + "/0.jpg";
     }
 
-    /**
-     * @param track The audio track for which the current position and total duration is to be found
-     * @return A string with the highlighted current position as the appropriate string in constants file
-     */
     public static String getAudioTrackBar(AudioTrack track) {
         long totalDuration = track.getDuration();
         long currentPosition = track.getPosition();
@@ -133,12 +107,6 @@ public class AudioTrackUtils {
         return val.toString();
     }
 
-    /**
-     * Changes the volume to a desired value
-     *
-     * @param evt The event being queried for information such as the channel
-     * @param vol The volume to be changed to
-     */
     public static void setVolume(MessageReceivedEvent evt, int vol) {
         if (vol < 0 || vol > Constants.MAX_VOL) {
             evt.getChannel()
@@ -150,32 +118,16 @@ public class AudioTrackUtils {
         evt.getChannel().sendMessage("Volume set to " + vol).queue();
     }
 
-    /**
-     * Pauses the bot's audio player
-     *
-     * @param evt The message received event associated with the pause request being sent
-     */
     public static void pause(MessageReceivedEvent evt) {
         AudioPlayer ap = Bot.trackManager.getGuildAudioPlayer(evt.getGuild()).getPlayer();
         ap.setPaused(true);
     }
 
-    /**
-     * Resumes the bot
-     *
-     * @param evt The message receieved event relating to the resume request
-     */
     public static void resume(MessageReceivedEvent evt) {
         AudioPlayer ap = Bot.trackManager.getGuildAudioPlayer(evt.getGuild()).getPlayer();
         ap.setPaused(false);
     }
 
-    /**
-     * Looks for a particular time in the track
-     *
-     * @param evt     The message received event containing information regarding the track which is to be seeked through
-     * @param seconds The time in seconds to be searched for in the currently playing track
-     */
     public static void seek(MessageReceivedEvent evt, int seconds) {
         try {
             AudioTrack track = Bot.trackManager
@@ -193,7 +145,7 @@ public class AudioTrackUtils {
                 int toMilliSeconds = seconds * 1000;
                 track.setPosition(toMilliSeconds);
                 evt.getChannel()
-                        .sendMessage("Set position of current track to " + seconds)
+                        .sendMessage("Set position of current track to " + CmdUtils.longToMMSS(seconds))
                         .queue();
             }
         } catch (NullPointerException e) {
@@ -201,12 +153,6 @@ public class AudioTrackUtils {
         }
     }
 
-    /**
-     * The track to be removed from the queue at the given index
-     *
-     * @param evt The message received event associated with the track to be removed
-     * @param idx The current index of the track to be removed
-     */
     public static void remove(MessageReceivedEvent evt, int idx) {
         BlockingQueue<AudioTrack> tracks = Bot.trackManager
                 .getGuildAudioPlayer(evt.getGuild())

--- a/src/main/java/me/afarrukh/hashbot/utils/CmdUtils.java
+++ b/src/main/java/me/afarrukh/hashbot/utils/CmdUtils.java
@@ -4,21 +4,6 @@ import java.util.concurrent.TimeUnit;
 
 public class CmdUtils {
 
-    /**
-     * The given string starting from the given start index and ending at a given index
-     *
-     * @param tokens     - the string array to be evaluated
-     * @param startIndex - the start index
-     * @param endIndex   - the end index
-     * @return - a string with all array elements given as a single string
-     */
-    public static String getParamsAsString(String[] tokens, int startIndex, int endIndex) {
-        StringBuilder params = new StringBuilder();
-        for (int i = startIndex; i <= endIndex; i++) params.append(tokens[i]).append(" ");
-
-        return params.toString().trim();
-    }
-
     public static String longToHHMMSS(long count) {
         return String.format(
                 "%02d:%02d:%02d",

--- a/src/main/java/me/afarrukh/hashbot/utils/EmbedUtils.java
+++ b/src/main/java/me/afarrukh/hashbot/utils/EmbedUtils.java
@@ -17,12 +17,6 @@ import java.util.concurrent.BlockingQueue;
 @SuppressWarnings("Duplicates")
 public class EmbedUtils {
 
-    /**
-     * @param gmm  The guild track manager
-     * @param evt  The message received event associated with the queue message request
-     * @param page The page of the message queue to be displayed
-     * @return An embed referring to the current queue of audio tracks playing. If not found it simply goes to the method for a single track embed.
-     */
     public static MessageEmbed getQueueMsg(GuildAudioTrackManager gmm, MessageReceivedEvent evt, int page) {
         try {
             EmbedBuilder eb = new EmbedBuilder();
@@ -84,12 +78,6 @@ public class EmbedUtils {
         }
     }
 
-    /**
-     * Returns an embed with the only track currently in the queue
-     *
-     * @param evt The event to get the channel to send it to
-     * @return A message embed with information on a single provided audio track
-     */
     public static MessageEmbed getSingleTrackEmbed(AudioTrack currentTrack, MessageReceivedEvent evt) {
         EmbedBuilder eb = new EmbedBuilder();
         StringBuilder sb = new StringBuilder(); // Building the title
@@ -108,12 +96,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * @param gmm The guild track manager associated with the embed being requested
-     * @param at  The audio track which has been queued
-     * @param evt The message received event containing information such as which channel to send to
-     * @return an embed referring to a track which has been queued to an audioplayer already playing a track
-     */
     public static MessageEmbed getQueuedEmbed(GuildAudioTrackManager gmm, AudioTrack at, MessageReceivedEvent evt) {
         TrackScheduler ts = gmm.getScheduler();
         EmbedBuilder eb = new EmbedBuilder();
@@ -139,10 +121,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * @param at The audio track which has been skipped to
-     * @return Returns an embed referring to the track which has been skipped to
-     */
     public static MessageEmbed getSkippedToEmbed(AudioTrack at) {
         EmbedBuilder eb = new EmbedBuilder();
         eb.setTitle("Skipped to");
@@ -155,10 +133,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * @param at The audio track which has been skipped
-     * @return an embed referring to the track which has been skipped, not to be confused with getSkippedToEmbed
-     */
     public static MessageEmbed getSkippedEmbed(AudioTrack at) {
         EmbedBuilder eb = new EmbedBuilder();
         eb.setTitle("Skipped track");
@@ -170,11 +144,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * @param gmm The track manager to query
-     * @param at  The audiotrack which is being added
-     * @return A message embed with the appropriate information for a track that has been queued to the top
-     */
     public static MessageEmbed getQueuedTopEmbed(GuildAudioTrackManager gmm, AudioTrack at) {
         TrackScheduler ts = gmm.getScheduler();
         EmbedBuilder eb = new EmbedBuilder();
@@ -196,12 +165,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * Gets an embed that returns a playlist that has been queued
-     *
-     * @param playlist The playlist to be added
-     * @return the MessageEmbed object to represent this playlist that has been queued
-     */
     public static MessageEmbed getPlaylistEmbed(AudioPlaylist playlist) {
         AudioTrack firstTrack = playlist.getSelectedTrack();
 
@@ -218,9 +181,6 @@ public class EmbedUtils {
         return eb.build();
     }
 
-    /**
-     * @return An embed which informs that nothing is playing right now
-     */
     public static MessageEmbed getNothingPlayingEmbed() {
         return new EmbedBuilder()
                 .setDescription("Nothing playing right now.")


### PR DESCRIPTION
Previous logic uses `wait` and `notifyAll` which are extremely primitive. Replacing these with modern executor services. Need to explore using the YouTube API itself to create a temporary playlist which will use the URIs for tracks and queue up tracks, then delete the playlist from YouTube straight after.